### PR TITLE
Fix unmapped sensor crashes without breaking existing power configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,11 +81,12 @@ cover:
     blind_id: "USZ"
     link_quality: lq_usz
     status: status_usz
-    power: power_usz 
+    voltage: voltage_usz
 
 ```
 
 Each cover supports open, close, stop, and set position (0 = open, 100 = closed).
+New configs should use `voltage:`. The legacy `power:` key is still accepted for backwards compatibility.
 
 ## Optional 📶 Link Quality, Voltage & Status Sensors
 
@@ -99,7 +100,7 @@ sensor:
     icon: "mdi:signal"
 
   - platform: template
-    id: power_usz
+    id: voltage_usz
     name: "Office Blind Voltage"
     unit_of_measurement: "V" # A reading of 0.00V indicates an AC or mains-powered motor.
     accuracy_decimals: 2

--- a/esphome/components/arc_bridge/README.md
+++ b/esphome/components/arc_bridge/README.md
@@ -262,6 +262,10 @@ cover:
     link_quality: lq_mlt
     status: status_mlt
 
+# If you expose the optional motor voltage sensor on a cover, prefer
+# `voltage:` in new configs. The legacy `power:` key remains supported
+# for backwards compatibility.
+
 sensor:
   - platform: template
     id: lq_usz

--- a/esphome/components/arc_bridge/arc_bridge.cpp
+++ b/esphome/components/arc_bridge/arc_bridge.cpp
@@ -389,20 +389,23 @@ void ARCBridgeComponent::parse_frame(const std::string &frame) {
 
   auto it_lq = lq_map_.find(id);
   auto it_status = status_map_.find(id);
+  sensor::Sensor *lq_sensor = (it_lq != lq_map_.end()) ? it_lq->second : nullptr;
+  text_sensor::TextSensor *status_sensor =
+      (it_status != status_map_.end()) ? it_status->second : nullptr;
 
   if (enl) {
-    if (it_status->second) it_status->second->publish_state("unavailable");
-    if (it_lq->second)     it_lq->second->publish_state(NAN);
+    if (status_sensor) status_sensor->publish_state("unavailable");
+    if (lq_sensor)     lq_sensor->publish_state(NAN);
     ESP_LOGW(TAG, "[%s] Lost link", id.c_str());
   }
   else if (enp) {
-    if (it_status->second) it_status->second->publish_state("unavailable");
-    if (it_lq->second)     it_lq->second->publish_state(NAN);
+    if (status_sensor) status_sensor->publish_state("unavailable");
+    if (lq_sensor)     lq_sensor->publish_state(NAN);
     ESP_LOGW(TAG, "[%s] Not paired", id.c_str());
   }
   else if (!std::isnan(dbm)) {
-    if (it_lq->second)     it_lq->second->publish_state(dbm);
-    if (it_status->second) it_status->second->publish_state("Online");
+    if (lq_sensor)     lq_sensor->publish_state(dbm);
+    if (status_sensor) status_sensor->publish_state("Online");
   }
 
   for (auto *cv : covers_) {

--- a/esphome/components/arc_bridge/cover.py
+++ b/esphome/components/arc_bridge/cover.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import cover, sensor, text_sensor
-from esphome.const import CONF_ID, CONF_NAME
+from esphome.const import CONF_ID, CONF_POWER, CONF_VOLTAGE
 
 DEPENDENCIES = ["uart"]
 AUTO_LOAD = ["cover", "sensor", "text_sensor"]
@@ -11,7 +11,6 @@ CONF_BLIND_ID = "blind_id"
 CONF_LINK_QUALITY = "link_quality"
 CONF_STATUS = "status"
 CONF_INVERT_POSITION = "invert_position"
-CONF_POWER = "power"
 
 arc_bridge_ns = cg.esphome_ns.namespace("arc_bridge")
 ARCBridgeComponent = arc_bridge_ns.class_("ARCBridgeComponent", cg.Component)
@@ -24,7 +23,8 @@ CONFIG_SCHEMA = cover.cover_schema(ARCCover).extend(
         cv.Required(CONF_BLIND_ID): cv.string,
         cv.Optional(CONF_LINK_QUALITY): cv.use_id(sensor.Sensor),
         cv.Optional(CONF_STATUS): cv.use_id(text_sensor.TextSensor),
-        cv.Optional(CONF_POWER): cv.use_id(sensor.Sensor), 
+        cv.Exclusive(CONF_POWER, "voltage_sensor"): cv.use_id(sensor.Sensor),
+        cv.Exclusive(CONF_VOLTAGE, "voltage_sensor"): cv.use_id(sensor.Sensor),
         cv.Optional(CONF_INVERT_POSITION, default=False): cv.boolean,
     }
 )
@@ -50,6 +50,7 @@ async def to_code(config):
         st = await cg.get_variable(config[CONF_STATUS])
         cg.add(bridge.map_status_sensor(config[CONF_BLIND_ID], st))
     
-    if CONF_POWER in config:
-        pw = await cg.get_variable(config[CONF_POWER])
-        cg.add(bridge.map_voltage_sensor(config[CONF_BLIND_ID], pw))
+    voltage_sensor_id = config.get(CONF_VOLTAGE, config.get(CONF_POWER))
+    if voltage_sensor_id is not None:
+        voltage_sensor = await cg.get_variable(voltage_sensor_id)
+        cg.add(bridge.map_voltage_sensor(config[CONF_BLIND_ID], voltage_sensor))


### PR DESCRIPTION
This PR supersedes #12 while preserving backward compatibility for existing ESPHome configs.

Credit to @defl for the original fix in #12 and for identifying the crash path during initial pairing / partial sensor setup.

What changed:
- guard `lq_map_` / `status_map_` lookups in `parse_frame()` so frames for blinds without mapped link-quality or status sensors do not dereference invalid iterators
- keep the legacy `power:` cover key working
- add `voltage:` as a non-breaking alias for new configs
- reject configs that specify both `power:` and `voltage:` on the same cover
- update docs to prefer `voltage:` while noting that `power:` is still supported for existing setups

Why this replaces #12 instead of merging it as-is:
- `#12` contains the core crash fix, but it also renames the public YAML key from `power` to `voltage`
- merging that rename directly would break existing user configs
- this PR keeps the bug fix and docs improvement while making the schema change additive instead of breaking

Validation:
- `python -m esphome compile %TEMP%\\arc_bridge_pr12_verify\\power_only.yaml`
- `python -m esphome compile %TEMP%\\arc_bridge_pr12_verify\\voltage_only.yaml`
- `python -m esphome config %TEMP%\\arc_bridge_pr12_verify\\both_keys.yaml`

Notes:
- the compile scenarios intentionally used configs without mapped `link_quality` / `status` sensors to mirror the configuration shape that exposed the crash
- I did not run a hardware UART repro in this session, so the runtime frame path is validated by code inspection plus config/build coverage, not live hardware exercise
