### PR TITLE
Improve grouped blind delivery retries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /esphome/components/arc_bridge/__pycache__
 /tests/__pycache__
 /esphome/components/arc_bridge_group/__pycache__
+/tests

--- a/README.md
+++ b/README.md
@@ -122,15 +122,7 @@ sensor:
     name: "Office Blind Link Quality"
     entity_category: diagnostic
     unit_of_measurement: "dBm"
-    icon: "mdi:signal"
-
-  - platform: template
-    id: voltage_usz
-    name: "Office Blind Voltage"
-    entity_category: diagnostic
-    unit_of_measurement: "V"
-    accuracy_decimals: 2
-    icon: "mdi:battery"
+    device_class: signal_strength
 
   - platform: template
     id: battery_usz
@@ -151,7 +143,7 @@ sensor:
     name: "Living Drape Link Quality"
     entity_category: diagnostic
     unit_of_measurement: "dBm"
-    icon: "mdi:signal"
+    device_class: signal_strength
 
 text_sensor:
   - platform: template
@@ -194,6 +186,8 @@ These are updated from ARC messages:
 - `limits`: `Unset`, `Upper/Lower Set`, `Upper/Lower/Preferred Set`
 - `voltage` / `power`: `0.00 V` indicates an AC or mains-powered motor
 - `battery_level`: derived from `pVc` using a fixed 3S Li-ion curve
+
+Use `device_class: signal_strength` for ARC RSSI sensors reported in `dBm`. If you later create a percentage-based signal sensor, do not reuse `device_class: signal_strength`.
 
 ## Manual Actions
 

--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ The bridge rotates through known blinds and queries them one at a time for posit
 |--------:|-------------|---------|
 | `auto_poll` | Enables background polling | `true` |
 | `auto_poll_interval` | Time between each blind query | `10s` |
-| `motion_tx_gap` | Internal spacing for motion commands | `200ms` |
+| `motion_tx_gap` | Minimum spacing between motion command transmissions | `200ms` |
 | `command_retries` | Retries safe motion commands after a missed reply | `1` |
-| `command_retry_timeout` | Wait time before verification and retry | `1500ms` |
+| `command_retry_timeout` | Wait time before retry/verification handling | `1500ms` |
 
 Setting `auto_poll_interval: 0s` disables polling completely.
 
@@ -111,7 +111,7 @@ cover:
     members: [usz, khn, hw4, j8u]
 ```
 
-`members:` takes existing `arc_bridge` cover IDs. Grouped moves are still sent one blind at a time, just with the faster motion gap.
+`members:` takes existing `arc_bridge` cover IDs. Grouped moves are queued in order; the bridge waits for each tracked motion command to reply, retry, or time out before sending the next tracked motion command.
 
 ## Optional Sensors
 

--- a/esphome/components/arc_bridge/README.md
+++ b/esphome/components/arc_bridge/README.md
@@ -280,43 +280,43 @@ sensor:
     name: "Office Blind Link Quality"
     entity_category: diagnostic
     unit_of_measurement: "dBm"
-    icon: "mdi:signal"
+    device_class: signal_strength
   - platform: template
     id: lq_zxe
     name: "Guest Blind Link Quality"
     entity_category: diagnostic
     unit_of_measurement: "dBm"
-    icon: "mdi:signal"
+    device_class: signal_strength
   - platform: template
     id: lq_nom
     name: "Living Drape Link Quality"
     entity_category: diagnostic
     unit_of_measurement: "dBm"
-    icon: "mdi:signal"
+    device_class: signal_strength
   - platform: template
     id: lq_ovj
     name: "Guest Drape Link Quality"
     entity_category: diagnostic
     unit_of_measurement: "dBm"
-    icon: "mdi:signal"
+    device_class: signal_strength
   - platform: template
     id: lq_txy
     name: "Living Window Link Quality"
     entity_category: diagnostic
     unit_of_measurement: "dBm"
-    icon: "mdi:signal"
+    device_class: signal_strength
   - platform: template
     id: lq_mlt
     name: "Living Door Link Quality"
     entity_category: diagnostic
     unit_of_measurement: "dBm"
-    icon: "mdi:signal"
+    device_class: signal_strength
   - platform: template
     id: lq_wrk
     name: "Workshop Drape Link Quality"
     entity_category: diagnostic
     unit_of_measurement: "dBm"
-    icon: "mdi:signal"
+    device_class: signal_strength
   - platform: template
     id: power_usz
     name: "Office Blind Voltage"
@@ -409,6 +409,8 @@ The optional sensors above are updated from ARC replies:
 - `limits`: `Unset`, `Upper/Lower Set`, `Upper/Lower/Preferred Set`
 - `power` / `voltage`: `0.00 V` means AC or mains-powered
 - `battery_level`: derived 3S Li-ion estimate from `pVc`
+
+Use `device_class: signal_strength` for ARC RSSI sensors reported in `dBm`. If you later expose signal quality as a percentage sensor, do not reuse `device_class: signal_strength`.
 
 There are no built-in discovery, refresh, or pairing ESPHome services in this repo. Use the bridge methods above instead.
 

--- a/esphome/components/arc_bridge/README.md
+++ b/esphome/components/arc_bridge/README.md
@@ -393,10 +393,10 @@ Use `device_class: shade` for roller / roman / zebra / cellular-style blinds and
 ## Notes
 
 - `auto_poll_interval` is per blind. The bridge rotates through known blinds instead of polling all blinds at once.
-- `motion_tx_gap` applies to motion commands such as open, close, stop, move, favorite, and jog.
-- `command_retries` and `command_retry_timeout` control the verification-and-retry path for safe motion commands.
+- `motion_tx_gap` is the minimum spacing between motion command transmissions.
+- `command_retries` and `command_retry_timeout` control retry/verification handling for safe motion commands.
 - `members:` in `arc_bridge_group` takes existing `arc_bridge` cover IDs.
-- Grouped motion is still serialized one blind at a time.
+- Grouped motion is queued in order; the bridge waits for each tracked motion command to reply, retry, or time out before sending the next tracked motion command.
 
 ## Optional Sensor Values
 

--- a/esphome/components/arc_bridge/arc_bridge.cpp
+++ b/esphome/components/arc_bridge/arc_bridge.cpp
@@ -153,6 +153,12 @@ void ARCBridgeComponent::process_tx_queue_() {
   }
 
   const TxQueueItem item = this->tx_queue_.front();
+  if (this->tx_item_blocked_by_pending_delivery_(item)) {
+    ESP_LOGVV(TAG, "[%s] TX deferred while awaiting another blind acknowledgement",
+              item.blind_id.c_str());
+    return;
+  }
+
   // Enforce safe ARC timing using the configured per-bridge motion gap
   const uint32_t required_gap = tx_gap_ms_for(item.pacing_class, this->motion_tx_gap_ms_);
   if (now - this->last_tx_millis_ < required_gap) {
@@ -402,6 +408,17 @@ void ARCBridgeComponent::acknowledge_pending_delivery_(const ParsedFrame &parsed
   this->pending_command_deliveries_.erase(it);
 }
 
+bool ARCBridgeComponent::tx_item_blocked_by_pending_delivery_(const TxQueueItem &item) const {
+  for (const auto &entry : this->pending_command_deliveries_) {
+    const TxQueueItem &pending_item = entry.second.item;
+    if (!tx_item_can_send_while_delivery_pending(item, pending_item.blind_id,
+                                                 pending_item.tracking_id)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 void ARCBridgeComponent::send_verification_query_(const std::string &id) {
   const std::string frame = "!" + id + "r?;";
   this->queue_tx_front(frame, TxPacingClass::STANDARD, false);
@@ -497,14 +514,14 @@ void ARCBridgeComponent::send_simple_(const std::string &id, char command,
 void ARCBridgeComponent::send_open(const std::string &id) {
   this->last_motion_millis_ = millis();
   this->drop_pending_polls_();
-  this->send_simple_(id, 'o', "", true, TxPacingClass::MOTION, false,
+  this->send_simple_(id, 'o', "", false, TxPacingClass::MOTION, false,
                      DeliveryExpectation::BLIND_REPLY, true, "o");
 }
 
 void ARCBridgeComponent::send_close(const std::string &id) {
   this->last_motion_millis_ = millis();
   this->drop_pending_polls_();
-  this->send_simple_(id, 'c', "", true, TxPacingClass::MOTION, false,
+  this->send_simple_(id, 'c', "", false, TxPacingClass::MOTION, false,
                      DeliveryExpectation::BLIND_REPLY, true, "c");
 }
 
@@ -526,7 +543,7 @@ void ARCBridgeComponent::send_move(const std::string &id, uint8_t percent) {
   char buffer[4];
   snprintf(buffer, sizeof(buffer), "%03u", percent);
   const std::string move_token = std::string("m") + buffer;
-  this->send_simple_(id, 'm', buffer, true, TxPacingClass::MOTION, false,
+  this->send_simple_(id, 'm', buffer, false, TxPacingClass::MOTION, false,
                      DeliveryExpectation::BLIND_REPLY, true, move_token, "m");
 }
 
@@ -582,21 +599,21 @@ void ARCBridgeComponent::send_raw_command(const std::string &cmd) {
 void ARCBridgeComponent::send_favorite(const std::string &id) {
   this->last_motion_millis_ = millis();
   this->drop_pending_polls_();
-  this->send_simple_(id, 'f', "", true, TxPacingClass::MOTION, false,
+  this->send_simple_(id, 'f', "", false, TxPacingClass::MOTION, false,
                      DeliveryExpectation::BLIND_REPLY, false, "f");
 }
 
 void ARCBridgeComponent::send_jog_open(const std::string &id) {
   this->last_motion_millis_ = millis();
   this->drop_pending_polls_();
-  this->send_simple_(id, 'o', "A", true, TxPacingClass::MOTION, false,
+  this->send_simple_(id, 'o', "A", false, TxPacingClass::MOTION, false,
                      DeliveryExpectation::BLIND_REPLY, false, "oA");
 }
 
 void ARCBridgeComponent::send_jog_close(const std::string &id) {
   this->last_motion_millis_ = millis();
   this->drop_pending_polls_();
-  this->send_simple_(id, 'c', "A", true, TxPacingClass::MOTION, false,
+  this->send_simple_(id, 'c', "A", false, TxPacingClass::MOTION, false,
                      DeliveryExpectation::BLIND_REPLY, false, "cA");
 }
 

--- a/esphome/components/arc_bridge/arc_bridge.h
+++ b/esphome/components/arc_bridge/arc_bridge.h
@@ -88,6 +88,7 @@ class ARCBridgeComponent : public Component, public uart::UARTDevice {
   void arm_pending_delivery_(const TxQueueItem &item, uint32_t now);
   void acknowledge_pending_delivery_(const ParsedFrame &parsed);
   void process_pending_deliveries_();
+  bool tx_item_blocked_by_pending_delivery_(const TxQueueItem &item) const;
   void send_verification_query_(const std::string &id);
   void publish_pairing_status_(const std::string &status);
   void publish_last_paired_id_(const std::string &id);

--- a/esphome/components/arc_bridge/arc_cover.cpp
+++ b/esphome/components/arc_bridge/arc_cover.cpp
@@ -55,8 +55,6 @@ void ARCCover::publish_raw_position(int device_pos) {
 
 void ARCCover::set_available(bool available) {
   if (!available) {
-    // Mark the entity unavailable using the component status flag
-    this->status_set_warning();
     this->current_operation = cover::COVER_OPERATION_IDLE;
     this->position = NAN;
     this->set_has_state(false);

--- a/esphome/components/arc_bridge/delivery.cpp
+++ b/esphome/components/arc_bridge/delivery.cpp
@@ -45,12 +45,12 @@ DeliveryTimeoutAction next_delivery_timeout_action(const PendingDeliveryPolicy &
     return DeliveryTimeoutAction::NONE;
   }
 
-  if (!policy.verification_sent) {
-    return DeliveryTimeoutAction::SEND_VERIFY_QUERY;
-  }
-
   if (policy.allow_retry && policy.retries_used < policy.retry_limit) {
     return DeliveryTimeoutAction::RETRY_COMMAND;
+  }
+
+  if (!policy.verification_sent) {
+    return DeliveryTimeoutAction::SEND_VERIFY_QUERY;
   }
 
   return DeliveryTimeoutAction::GIVE_UP;

--- a/esphome/components/arc_bridge/tx_queue.cpp
+++ b/esphome/components/arc_bridge/tx_queue.cpp
@@ -22,5 +22,17 @@ void drop_pending_poll_items(std::deque<TxQueueItem> &queue) {
       queue.end());
 }
 
+bool tx_item_can_send_while_delivery_pending(const TxQueueItem &item,
+                                             const std::string &pending_blind_id,
+                                             uint32_t pending_tracking_id) {
+  if (pending_blind_id.empty() || pending_tracking_id == 0) {
+    return true;
+  }
+  if (item.delivery_expectation == DeliveryExpectation::NONE) {
+    return true;
+  }
+  return item.blind_id == pending_blind_id && item.tracking_id == pending_tracking_id;
+}
+
 }  // namespace arc_bridge
 }  // namespace esphome

--- a/esphome/components/arc_bridge/tx_queue.h
+++ b/esphome/components/arc_bridge/tx_queue.h
@@ -32,6 +32,9 @@ struct TxQueueItem {
 uint32_t tx_gap_ms_for(TxPacingClass pacing_class,
                        uint32_t motion_tx_gap_ms = DEFAULT_MOTION_TX_GAP_MS);
 void drop_pending_poll_items(std::deque<TxQueueItem> &queue);
+bool tx_item_can_send_while_delivery_pending(const TxQueueItem &item,
+                                             const std::string &pending_blind_id,
+                                             uint32_t pending_tracking_id);
 
 }  // namespace arc_bridge
 }  // namespace esphome

--- a/tests/delivery_test.cpp
+++ b/tests/delivery_test.cpp
@@ -130,15 +130,15 @@ void test_timeout_action_progression() {
 
   require(next_delivery_timeout_action(policy, 1200) == DeliveryTimeoutAction::NONE,
           "timeouts should stay idle before the configured threshold");
-  require(next_delivery_timeout_action(policy, 1700) == DeliveryTimeoutAction::SEND_VERIFY_QUERY,
-          "first timeout should trigger a verification query");
-
-  policy.verification_sent = true;
-  policy.last_activity_ms = 1700;
-  require(next_delivery_timeout_action(policy, 3300) == DeliveryTimeoutAction::RETRY_COMMAND,
-          "second timeout should retry when retries remain");
+  require(next_delivery_timeout_action(policy, 1700) == DeliveryTimeoutAction::RETRY_COMMAND,
+          "first timeout should retry retryable motion commands before verification");
 
   policy.retries_used = 1;
+  policy.last_activity_ms = 1700;
+  require(next_delivery_timeout_action(policy, 3300) == DeliveryTimeoutAction::SEND_VERIFY_QUERY,
+          "retry exhaustion should trigger a verification query");
+
+  policy.verification_sent = true;
   policy.last_activity_ms = 3300;
   require(next_delivery_timeout_action(policy, 4900) == DeliveryTimeoutAction::GIVE_UP,
           "timeouts should give up after the retry limit is reached");

--- a/tests/run_component_validation.py
+++ b/tests/run_component_validation.py
@@ -104,6 +104,7 @@ sensor:
     name: "Office Blind Link Quality"
     entity_category: diagnostic
     unit_of_measurement: "dBm"
+    device_class: signal_strength
   - platform: template
     id: speed_usz
     name: "Office Blind Speed"

--- a/tests/tx_queue_test.cpp
+++ b/tests/tx_queue_test.cpp
@@ -8,6 +8,7 @@
 using esphome::arc_bridge::TxPacingClass;
 using esphome::arc_bridge::TxQueueItem;
 using esphome::arc_bridge::drop_pending_poll_items;
+using esphome::arc_bridge::tx_item_can_send_while_delivery_pending;
 using esphome::arc_bridge::tx_gap_ms_for;
 
 namespace {
@@ -67,12 +68,36 @@ void test_priority_motion_sits_ahead_of_polls() {
           "dropping pending polls should preserve the priority motion frame");
 }
 
+void test_delivery_gating_allows_only_matching_retry_or_untracked_frames() {
+  TxQueueItem other_motion{"!USZo;", TxPacingClass::MOTION, false, "USZ",
+                           esphome::arc_bridge::DeliveryExpectation::BLIND_REPLY,
+                           true, 2, "o", ""};
+  require(!tx_item_can_send_while_delivery_pending(other_motion, "QJ0", 1),
+          "new motion for another blind should wait while delivery is pending");
+
+  TxQueueItem matching_retry{"!QJ0o;", TxPacingClass::MOTION, false, "QJ0",
+                             esphome::arc_bridge::DeliveryExpectation::BLIND_REPLY,
+                             true, 1, "o", ""};
+  require(tx_item_can_send_while_delivery_pending(matching_retry, "QJ0", 1),
+          "matching retry should be allowed through pending-delivery gating");
+
+  TxQueueItem verification_query{"!QJ0r?;", TxPacingClass::STANDARD, false, "",
+                                 esphome::arc_bridge::DeliveryExpectation::NONE,
+                                 false, 0, "", ""};
+  require(tx_item_can_send_while_delivery_pending(verification_query, "QJ0", 1),
+          "untracked verification query should be allowed while delivery is pending");
+
+  require(tx_item_can_send_while_delivery_pending(other_motion, "", 0),
+          "delivery gating should not block when no delivery is pending");
+}
+
 }  // namespace
 
 int main() {
   test_gap_mapping();
   test_drop_pending_polls_removes_only_poll_items();
   test_priority_motion_sits_ahead_of_polls();
+  test_delivery_gating_allows_only_matching_retry_or_untracked_frames();
   std::cout << "tx queue tests passed" << std::endl;
   return 0;
 }


### PR DESCRIPTION
## Summary

This PR hardens grouped ARC blind commands so multiple `arc_bridge_group` executions do not burst tracked motion commands faster than the bridge can confirm them.

Changes include:

- Gate tracked TX queue items while another blind command is still awaiting delivery confirmation, retry, or timeout.
- Preserve FIFO ordering for normal motion commands instead of pushing every open/close/move to the front of the queue.
- Retry safe motion commands before sending a verification `r?` query, so a reachability response cannot accidentally suppress the actual motion retry.
- Keep priority/front-of-queue behavior for verification, stop, pairing, and raw commands where immediate handling is still appropriate.
- Remove the generic per-blind ESPHome warning flag that produced `<unknown> set Warning flag: unspecified`; the explicit ARC logs and entity state updates remain.
- Refresh README wording around grouped motion, retries, and RSSI signal-strength device class guidance.

## Root Cause

Grouped covers call each member immediately. The bridge previously accepted those calls as a burst of priority queue entries, so several blind motion commands could be transmitted while earlier blinds were still waiting for acknowledgements. If a blind missed the original motion command, the old retry path first queued a verification `r?`; a position response to that query could count as delivery confirmation, causing the component to skip the actual motion retry.

## Impact

Grouped motion is now delivery-aware: the bridge sends the next tracked motion command only after the current tracked command has replied, retried, or timed out. This should reduce the observed behavior where only some blinds in one or more executed groups respond until the command is sent again.

## Validation

Ran locally:

- `python tests\run_delivery_test.py`
- `python tests\run_tx_queue_test.py`
- `python tests\run_protocol_parser_test.py`
- `python tests\run_pairing_test.py`
- `python tests\run_battery_curve_test.py`
- `python tests\run_arc_cover_warning_test.py`
- `python tests\run_component_validation.py`
- `git diff --check`

`run_component_validation.py` compiled the generated ESPHome config for both ESP-IDF and Arduino.

Not validated on live blind/RF hardware in this session.